### PR TITLE
Fix Clippy lints

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -7,9 +7,9 @@ use vrs::structs::server::Server;
 
 pub fn main() -> std::io::Result<()> {
     let server = Arc::new(Server::new()?);
-    match MULTITHREADING {
-        true => server.start_multithread()?,
-        false => server.start_singlethread()?,
+    if MULTITHREADING {
+        server.start_multithread()
+    } else {
+        server.start_singlethread()
     }
-    Ok(())
 }

--- a/src/structs/responsebuilder.rs
+++ b/src/structs/responsebuilder.rs
@@ -90,7 +90,7 @@ impl<'a> ResponseBuilder<'a> {
             _ => panic!("Invalid status code provided"),
         });
 
-        for (key, val) in self.headers.iter() {
+        for (key, val) in &self.headers {
             response.push_str("\r\n");
             response.push_str(format!("{}:{}", key, val).as_str());
         }
@@ -99,5 +99,11 @@ impl<'a> ResponseBuilder<'a> {
         response.push_str(self.body.unwrap());
 
         response
+    }
+}
+
+impl<'a> Default for ResponseBuilder<'a> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/structs/uri.rs
+++ b/src/structs/uri.rs
@@ -13,7 +13,7 @@ impl URI {
         }
     }
 
-    pub fn find(&mut self, headers_buffer: &String) {
+    pub fn find(&mut self, headers_buffer: &str) {
         let mut uri = String::new();
 
         for (i, c) in headers_buffer.chars().enumerate() {
@@ -52,8 +52,7 @@ impl URI {
 
         for component in components {
             match component {
-                Component::Prefix(_) => return false, // Should be unreachable
-                Component::RootDir => return false,   // Should be unreachable
+                Component::RootDir | Component::Prefix(_) => return false, // Should be unreachable
                 Component::CurDir => {
                     if result.as_os_str().is_empty() {
                         // If you've already stripped the leading / from the requested path, this should no-op
@@ -69,5 +68,11 @@ impl URI {
             };
         }
         true
+    }
+}
+
+impl Default for URI {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/util/headers.rs
+++ b/src/util/headers.rs
@@ -25,12 +25,10 @@ pub fn find_buf_headers(buf: &[u8; 1024]) -> Result<HashMap<String, String>, Err
             curr_header_name = String::new();
             curr_header_value = String::new();
             found_colon = false;
-        } else {
-            if !found_colon {
-                curr_header_name.push(c);
-            } else if found_colon && c != ' ' {
-                curr_header_value.push(c);
-            }
+        } else if !found_colon {
+            curr_header_name.push(c);
+        } else if found_colon && c != ' ' {
+            curr_header_value.push(c);
         }
     }
 

--- a/src/util/response.rs
+++ b/src/util/response.rs
@@ -13,13 +13,13 @@ pub type ServerResponse<'a> = Result<OkResponse, ErrorResponse>;
 
 pub fn handle_response(response: ServerResponse) -> String {
     match response {
-        Ok((headers, file_ext, file)) => create_response(headers, file_ext, file, 200),
-        Err((headers, status)) => create_response(headers, None, None, status),
+        Ok((headers, file_ext, file)) => create_response(&headers, file_ext, file, 200),
+        Err((headers, status)) => create_response(&headers, None, None, status),
     }
 }
 
 pub fn create_response(
-    req_headers: Header,
+    req_headers: &Header,
     file_ext: Option<String>,
     file: Option<File>,
     status_code: u16,
@@ -73,10 +73,7 @@ pub fn create_response(
 fn find_file(filename: &str) -> File {
     let url = [ABSOLUTE_STATIC_CONTENT_PATH, "/", filename].concat();
 
-    let file =
-        fs::File::open(&url).expect(format!("{filename} file doesn't exist ('{}')", &url).as_str());
-
-    file
+    fs::File::open(&url).unwrap_or_else(|_| panic!("{filename} file doesn't exist ('{}')", url))
 }
 
 fn find_mime_type(file_extension: &str) -> &str {


### PR DESCRIPTION
This PR cleans up multiple Clippy lints that trigger on the current main branch. One of these lints in particular, [clippy::unused_io_amount](https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount), can lead to transient errors that fail to write a complete response body and randomly. The remaining lints are for the most part stylistic choices that are considered idiomatic in the Rust world, and/or switching usage of owned types to borrowed types when the owned type isn't needed in function arguments (e.g. `String` -> `&str`).