### PR TITLE
Make CI and tests a little more useful

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,5 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
+    - name: Lint
+      run: cargo clippy --verbose
     - name: Run tests
       run: cargo test --verbose

--- a/src/enums/status.rs
+++ b/src/enums/status.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TestStatusCode {
     DirResponse,
     OK,

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -71,12 +71,12 @@ mod tests {
             ),
         );
 
-        assert!(matches!(test_1, TestStatusCode::OK));
-        assert!(matches!(test_2, TestStatusCode::BadRequest));
-        assert!(matches!(test_3, TestStatusCode::NotFound));
-        assert!(matches!(test_4, TestStatusCode::BadRequest));
-        assert!(matches!(test_5, TestStatusCode::CORSError));
-        assert!(matches!(test_6, TestStatusCode::MethodNotAllowed));
+        assert_eq!(test_1, TestStatusCode::OK);
+        assert_eq!(test_2, TestStatusCode::BadRequest);
+        assert_eq!(test_3, TestStatusCode::NotFound);
+        assert_eq!(test_4, TestStatusCode::BadRequest);
+        assert_eq!(test_5, TestStatusCode::CORSError);
+        assert_eq!(test_6, TestStatusCode::MethodNotAllowed);
 
         Ok(())
     }


### PR DESCRIPTION
This PR adds running the Clippy checks to CI and changes the `matches!` invocations in the unit tests for `assert_eq!`, causing failing tests to automatically print the expected and received values. On my machine, both Clippy and tests fail, but I think it's worth the time to mark the failures in CI rather than only seeing them locally.